### PR TITLE
[not for merge] Example of .waitForElementVisible and .click failures passing

### DIFF
--- a/examples/cucumber/features/duckduckgo-search.feature
+++ b/examples/cucumber/features/duckduckgo-search.feature
@@ -3,6 +3,7 @@ Feature: DuckDuckGo
 Scenario: Searching DuckDuckGo
 
   Given I open DuckDuckGo search page
+  Then I click an element that doesn't exist
   Then the title is "DuckDuckGo — Privacy, simplified."
   And the DuckDuckGo search form exists
 

--- a/examples/cucumber/step-definitions/steps.js
+++ b/examples/cucumber/step-definitions/steps.js
@@ -1,5 +1,5 @@
 import { client } from 'nightwatch-api';
-import { Given, Then } from 'cucumber';
+import { Given, Then, When } from 'cucumber';
 
 Given(/^I open Google`s search page$/, async () => {
   await client.url('http://google.com');
@@ -7,6 +7,10 @@ Given(/^I open Google`s search page$/, async () => {
 
 Given(/^I open DuckDuckGo search page$/, async () => {
   await client.url('https://duckduckgo.com/');
+});
+
+When(/^I click an element that doesn\'t exist$/, async () => {
+  await client.waitForElementVisible('#thisshouldfail', 5000).click('#thisshouldfail');
 });
 
 Then(/^the title is "(.*?)"$/, async text => {


### PR DESCRIPTION
Results:

```
14:17 $ npm run test

> nightwatch-api-cucumber@1.0.0 test /Users/rob/Documents/git/nightwatch-api/examples/cucumber
> start-server-and-test test:setup http-get://localhost:4444/status test:run

starting server using command "npm run test:setup"
and when url "http-get://localhost:4444/status" is responding
running tests using command "test:run"

> nightwatch-api-cucumber@1.0.0 test:setup /Users/rob/Documents/git/nightwatch-api/examples/cucumber
> babel-node test/server.js


> nightwatch-api-cucumber@1.0.0 test:run /Users/rob/Documents/git/nightwatch-api/examples/cucumber
> cucumber-js --require-module babel-core/register --require test/support --require step-definitions --format node_modules/cucumber-pretty

(node:95250) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methodsinstead.
Feature: DuckDuckGo

  Scenario: Searching DuckDuckGo
    Given I open DuckDuckGo search page
    Then I click an element that doesn't exist
✖ Timed out while waiting for element <#thisshouldfail> to be present for 5000 milliseconds. - expected "visible" but got: "not found"
    at World.<anonymous> (/Users/rob/Documents/git/nightwatch-api/examples/cucumber/step-definitions/steps.js:14:6)

   An error occurred while running .click() command on <#thisshouldfail>: no such element: Unable to locate element: {"method":"css selector","selector":"#thisshouldfail"}
       at process._tickCallback (internal/process/next_tick.js:68:7)
    Then the title is "DuckDuckGo — Privacy, simplified."
    And the DuckDuckGo search form exists

  Scenario: Searching DuckDuckGo again
    Given I open DuckDuckGo search page
    Then the title is "DuckDuckGo — Privacy, simplified."
    And the DuckDuckGo search form exists

Feature: Google Search

  Scenario: Searching Google
    Given I open Google`s search page
    Then the title is "Google"
    And the Google search form exists

  Scenario: Searching Google again
    Given I open Google`s search page
    Then the title is "Google"
    And the Google search form exists

4 scenarios (4 passed)
13 steps (13 passed)
0m07.382s
```